### PR TITLE
use bcryptjs instead of bcrypt-nodejs

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -1,5 +1,5 @@
 const crypto = require('crypto');
-const bcrypt = require('bcrypt-nodejs');
+const bcrypt = require('bcryptjs');
 const mongoose = require('mongoose');
 
 const userSchema = new mongoose.Schema(

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "array-shuffle": "^2.0.0",
     "async-mutex": "^0.3.0",
     "babel-loader": "^8.2.2",
-    "bcrypt-nodejs": "^0.0.3",
+    "bcryptjs": "^2.4.3",
     "bignumber.js": "^9.0.1",
     "bluebird": "^3.7.2",
     "body-parser": "^1.19.0",


### PR DESCRIPTION
[hiromi-mi/esolang-codegolf-7 ブランチ](https://github.com/hiromi-mi/esolang-battle) 由来の Pull Request です。

https://www.npmjs.com/package/bcrypt-nodejs がメンテナンスモードに入ったため、https://github.com/kelektiv/node.bcrypt.js に移行しました。