### PR TITLE
Set appropriate cache-control header

### DIFF
--- a/app.js
+++ b/app.js
@@ -146,7 +146,7 @@ app.use((req, res, next) => {
 	}
 	next();
 });
-app.use(express.static(path.join(__dirname, 'public'), {maxAge: 31557600000}));
+app.use(express.static(path.join(__dirname, 'public'), {maxAge: 0}));
 
 /*
  * Primary app routes.


### PR DESCRIPTION
Setting too long `max-age` can cause unexpected behavior, especially when using with CDN such as Cloudflare.