### PR TITLE
Update three.js addons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,8 +57,6 @@
         "shell-escape": "^0.2.0",
         "socket.io": "^4.6.1",
         "three": "^0.152.2",
-        "three-orbitcontrols": "^2.110.3",
-        "three-trackballcontrols": "0.9.0",
         "tmp": "^0.2.1",
         "utf-8-validate": "^6.0.3",
         "uuid": "^9.0.0",
@@ -12054,23 +12052,6 @@
       "resolved": "https://registry.npmjs.org/three/-/three-0.152.2.tgz",
       "integrity": "sha512-Ff9zIpSfkkqcBcpdiFo2f35vA9ZucO+N8TNacJOqaEE6DrB0eufItVMib8bK8Pcju/ZNT6a7blE1GhTpkdsILw=="
     },
-    "node_modules/three-orbitcontrols": {
-      "version": "2.110.3",
-      "resolved": "https://registry.npmjs.org/three-orbitcontrols/-/three-orbitcontrols-2.110.3.tgz",
-      "integrity": "sha512-BNNbksJwbN3/MmT0X/gjz5ZCchm7bjk26SUdtJYRxfEYjDfkb/0PeUTHE/KuyJ5vb/owK3mojyy3vcqDx99sRA==",
-      "deprecated": "three-js exposes real modules now via three/examples/jsm/...\nfor example to import Orbit, do\nimport { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'\n",
-      "peerDependencies": {
-        "three": ">= 0.110.0"
-      }
-    },
-    "node_modules/three-trackballcontrols": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/three-trackballcontrols/-/three-trackballcontrols-0.9.0.tgz",
-      "integrity": "sha512-Z6HmIJnP70r5uONvcPCdLEF0SsG1kbGzNb7qQYj3c7b6v2E3XTlbNpZsgTjt36oKm0Z2tU11D6EbW4i8KIHuqA==",
-      "peerDependencies": {
-        "three": ">= 0.86 <= 1.0"
-      }
-    },
     "node_modules/tiny-emitter": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
@@ -22071,18 +22052,6 @@
       "version": "0.152.2",
       "resolved": "https://registry.npmjs.org/three/-/three-0.152.2.tgz",
       "integrity": "sha512-Ff9zIpSfkkqcBcpdiFo2f35vA9ZucO+N8TNacJOqaEE6DrB0eufItVMib8bK8Pcju/ZNT6a7blE1GhTpkdsILw=="
-    },
-    "three-orbitcontrols": {
-      "version": "2.110.3",
-      "resolved": "https://registry.npmjs.org/three-orbitcontrols/-/three-orbitcontrols-2.110.3.tgz",
-      "integrity": "sha512-BNNbksJwbN3/MmT0X/gjz5ZCchm7bjk26SUdtJYRxfEYjDfkb/0PeUTHE/KuyJ5vb/owK3mojyy3vcqDx99sRA==",
-      "requires": {}
-    },
-    "three-trackballcontrols": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/three-trackballcontrols/-/three-trackballcontrols-0.9.0.tgz",
-      "integrity": "sha512-Z6HmIJnP70r5uONvcPCdLEF0SsG1kbGzNb7qQYj3c7b6v2E3XTlbNpZsgTjt36oKm0Z2tU11D6EbW4i8KIHuqA==",
-      "requires": {}
     },
     "tiny-emitter": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -67,8 +67,6 @@
     "shell-escape": "^0.2.0",
     "socket.io": "^4.6.1",
     "three": "^0.152.2",
-    "three-orbitcontrols": "^2.110.3",
-    "three-trackballcontrols": "0.9.0",
     "tmp": "^0.2.1",
     "utf-8-validate": "^6.0.3",
     "uuid": "^9.0.0",

--- a/public/js/contests/4/map.js
+++ b/public/js/contests/4/map.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
-import OrbitControls from 'three-orbitcontrols';
-import TrackballControls from 'three-trackballcontrols';
+import {OrbitControls} from 'three/addons/controls/OrbitControls';
+import {TrackballControls} from 'three/addons/controls/TrackballControls';
 
 import snubDodecahedron from '../../../../data/snub-dodecahedron.js';
 

--- a/public/js/contests/mayfes2021-day2/map.js
+++ b/public/js/contests/mayfes2021-day2/map.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
-import OrbitControls from 'three-orbitcontrols';
-import TrackballControls from 'three-trackballcontrols';
+import {OrbitControls} from 'three/addons/controls/OrbitControls';
+import {TrackballControls} from 'three/addons/controls/TrackballControls';
 
 import truncatedCuboctahedron from '../../../../data/truncated-cuboctahedron';
 


### PR DESCRIPTION
https://esolang.hakatashi.com/contests/mayfes2021-day2 https://esolang.hakatashi.com/contests/4

This PR fixes these pages.

`three-orbitcontrols` and `three-trackballcontrols` are deprecated and now included in three.js main package.